### PR TITLE
add noFuzzyMatching flag to msgmerge config

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,11 +115,12 @@ function msgmerge ( config, potFile, poFile, callback ) {
     ];
 
     // optional flags
-    config.indent     && command.push('--indent');
-    config.noLocation && command.push('--no-location');
-    config.noWrap     && command.push('--no-wrap');
-    config.sortOutput && command.push('--sort-output');
-    config.sortByFile && command.push('--sort-by-file');
+    config.indent          && command.push('--indent');
+    config.noLocation      && command.push('--no-location');
+    config.noWrap          && command.push('--no-wrap');
+    config.sortOutput      && command.push('--sort-output');
+    config.sortByFile      && command.push('--sort-by-file');
+    config.noFuzzyMatching && command.push('--no-fuzzy-matching');
 
     // merge
     command.push(poFile);


### PR DESCRIPTION
'--no-fuzzy-matching' flag disable generation of automatic fuzzy translations